### PR TITLE
 Add textarea resize option to myStyles.css

### DIFF
--- a/CodeTree/Innovator/Client/customer/myStyles.css
+++ b/CodeTree/Innovator/Client/customer/myStyles.css
@@ -22,6 +22,10 @@ label {
     font-weight: bold;
 }
 
+textarea {
+    resize: none;
+}
+
 input[type="text"],
 input[type="date"],
 input[type="datetime"],


### PR DESCRIPTION
Resize property for text areas is set to "none" to prevent resizing by the user.